### PR TITLE
add alt attribute to banner img tag

### DIFF
--- a/includes/widget.php
+++ b/includes/widget.php
@@ -130,6 +130,7 @@ class AffiliateWP_Affiliate_Banners extends WP_Widget {
 			}
 			// Window
 			$open_in = ( $window != '' ) ? '_blank': '_parent';
+			// alt attribute - AffiliateWP tagline
 			$alt_text = __( 'The best affiliate marketing plugin for WordPress', 'affiliatewp-banners-widget' );
 			echo '<a href="' . $affiliate_url . '" target="' . $open_in . '"><img src="' . AFFILIATEWP_BANNERS_WIDGET_ASSETS . '' . $size . '.png" alt="' . $alt_text . '" /></a>';
 			echo '</div>';


### PR DESCRIPTION
While I've seen some discussion on whether or not it's required, the purpose it would serve (or even a title attribute) in this case calls for one, in my opinion. If for whatever reason the image doesn't load, I think AffiliateWP's tagline is pretty intriguing and can still do the job with text on-screen.
