### PR TITLE
Affiliate links should have rel="nofollow"

### DIFF
--- a/includes/widget.php
+++ b/includes/widget.php
@@ -132,7 +132,7 @@ class AffiliateWP_Affiliate_Banners extends WP_Widget {
 			$open_in = ( $window != '' ) ? '_blank': '_parent';
 			// alt attribute - AffiliateWP tagline
 			$alt_text = __( 'The best affiliate marketing plugin for WordPress', 'affiliatewp-banners-widget' );
-			echo '<a href="' . $affiliate_url . '" target="' . $open_in . '"><img src="' . AFFILIATEWP_BANNERS_WIDGET_ASSETS . '' . $size . '.png" alt="' . $alt_text . '" /></a>';
+			echo '<a href="' . $affiliate_url . '" target="' . $open_in . '" rel="nofollow"><img src="' . AFFILIATEWP_BANNERS_WIDGET_ASSETS . '' . $size . '.png" alt="' . $alt_text . '" /></a>';
 			echo '</div>';
 		}
 		echo $args['after_widget'];


### PR DESCRIPTION
Affiliate links should have rel="nofollow" to comply with Google quality guidelines.

http://www.youtube.com/watch?v=F0LJwwTxJVo

Also affiliate links can be considered paid links, and paid links must contain rel="nofollow" to avoid penalizations in your domain (and linked domain) from Google.
